### PR TITLE
Upgrade to runtime 0.1.x

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.1.1
+  BASE_IMAGE_VERSION: 0.1.2
 
 jobs:
   docker:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.1.0
+  BASE_IMAGE_VERSION: 0.1.1
 
 jobs:
   docker:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.0.2
+  BASE_IMAGE_VERSION: 0.1.0
 
 jobs:
   docker:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.1.2
+  RUNTIME_VERSION: 0.1.5
 
 jobs:
   docker:
@@ -33,10 +33,10 @@ jobs:
           target: production
           push: false
           tags: | 
-            ${{ env.IMAGE_FQDN }}:latest
+            ${{ env.IMAGE_FQDN }}:production
           build-args: |
             VERSION=0.0.1-snapshot
-            BASE_IMAGE_VERSION=${{ env.BASE_IMAGE_VERSION }}
+            RUNTIME_VERSION=${{ env.RUNTIME_VERSION }}
       - name: Build dev
         uses: docker/build-push-action@v3
         with:
@@ -45,7 +45,7 @@ jobs:
           target: development
           push: false
           tags: |
-            ${{ env.IMAGE_FQDN }}:latest
+            ${{ env.IMAGE_FQDN }}:development
           build-args: |
             VERSION=0.0.1-snapshot
-            BASE_IMAGE_VERSION=${{ env.BASE_IMAGE_VERSION }}
+            RUNTIME_VERSION=${{ env.RUNTIME_VERSION }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.0.1
+  BASE_IMAGE_VERSION: 0.1.0
 
 jobs:
   docker:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.1.1
+  BASE_IMAGE_VERSION: 0.1.2
 
 jobs:
   docker:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.1.0
+  BASE_IMAGE_VERSION: 0.1.1
 
 jobs:
   docker:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_FQDN: ghcr.io/eugenmayer/kontextwork-converter
-  BASE_IMAGE_VERSION: 0.1.2
+  RUNTIME_VERSION: 0.1.5
 
 jobs:
   docker:
@@ -34,10 +34,11 @@ jobs:
           target: production
           tags: | 
             ${{ env.IMAGE_FQDN }}:${{ github.ref_name }}
-            ${{ env.IMAGE_FQDN }}:latest
+            ${{ env.IMAGE_FQDN }}:production-${{ github.ref_name }}
+            ${{ env.IMAGE_FQDN }}:production
           build-args: |
             VERSION=${{ github.ref_name }}
-            BASE_IMAGE_VERSION=${{ env.BASE_IMAGE_VERSION }}
+            RUNTIME_VERSION=${{ env.RUNTIME_VERSION }}
       - name: Build and publish development
         uses: docker/build-push-action@v3
         with:
@@ -46,8 +47,8 @@ jobs:
           push: true
           target: development
           tags: |
-            ${{ env.IMAGE_FQDN }}:dev-latest
-            ${{ env.IMAGE_FQDN }}:dev-${{ github.ref_name }}
+            ${{ env.IMAGE_FQDN }}:development
+            ${{ env.IMAGE_FQDN }}:development-${{ github.ref_name }}
           build-args: |
             VERSION=${{ github.ref_name }}
-            BASE_IMAGE_VERSION=${{ env.BASE_IMAGE_VERSION }}
+            RUNTIME_VERSION=${{ env.RUNTIME_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE_VERSION=0.1.0
 # ------------------------- builder
-FROM bellsoft/liberica-openjdk-debian:21 as builder
+FROM bellsoft/liberica-openjdk-debian:17 as builder
 RUN mkdir -p /src
 COPY . /src
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_IMAGE_VERSION=0.0.2
+ARG BASE_IMAGE_VERSION=0.1.0
 # ------------------------- builder
-FROM bellsoft/liberica-openjdk-debian:17 as builder
+FROM bellsoft/liberica-openjdk-debian:21 as builder
 RUN mkdir -p /src
 COPY . /src
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,59 @@
-ARG BASE_IMAGE_VERSION=0.1.0
+ARG RUNTIME_VERSION
+
 # ------------------------- builder
 FROM bellsoft/liberica-openjdk-debian:17 as builder
+ARG VERSION=0.0.1-snapshot
+
 RUN mkdir -p /src
 COPY . /src
 WORKDIR /src
 
-ARG VERSION=0.0.1-snapshot
-
 RUN  ./gradlew --no-daemon -Pversion=$VERSION clean build \
   && mkdir -p /dist && cp /src/build/libs/officeconverter-$VERSION.jar /dist/production.jar
 
-# --------------------------- appbase image
-FROM ghcr.io/jodconverter/jodconverter-runtime:$BASE_IMAGE_VERSION as appbase
-COPY ./bin/docker-entrypoint.sh /docker-entrypoint.sh
+# --------------------------- production image
+ARG RUNTIME_VERSION
+FROM ghcr.io/jodconverter/jodconverter-runtime:$RUNTIME_VERSION as production
 
+######## COMMON BLOCK - PLEASE SYNC WITH DEV IMAGE ############
+ENV JAR_FILE_NAME=officeconverter.jar
+ENV JAR_FILE_BASEDIR=/opt/app
+ENV LOG_BASE_DIR=/var/log
+
+COPY ./bin/docker-entrypoint.sh /docker-entrypoint.sh
 RUN mkdir -p ${JAR_FILE_BASEDIR} /etc/app \
   && touch /etc/app/application.properties /var/log/app.log /var/log/app.err \
   && chmod +x /docker-entrypoint.sh \
   && chown $NONPRIVUSER:$NONPRIVGROUP /var/log/app.log /var/log/app.err
 
+COPY --from=builder /dist/production.jar ${JAR_FILE_BASEDIR}/${JAR_FILE_NAME}
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
+EXPOSE 8080
+######## / COMMON BLOCK - PLEASE SYNC WITH DEV IMAGE / ############
 CMD ["--spring.config.additional-location=optional:/etc/app/"]
 
-# --------------------------- production image
-FROM appbase as production
+# --------------------------- development image
+ARG RUNTIME_VERSION
+FROM ghcr.io/jodconverter/jodconverter-runtime:jdk-$RUNTIME_VERSION as development
+
+######## COMMON BLOCK - PLEASE SYNC WITH PROD IMAGE ############
 ENV JAR_FILE_NAME=officeconverter.jar
 ENV JAR_FILE_BASEDIR=/opt/app
 ENV LOG_BASE_DIR=/var/log
-COPY --from=builder /dist/production.jar ${JAR_FILE_BASEDIR}/${JAR_FILE_NAME}
-EXPOSE 8080
 
-# --------------------------- development image
-FROM production as development
+COPY ./bin/docker-entrypoint.sh /docker-entrypoint.sh
+RUN mkdir -p ${JAR_FILE_BASEDIR} /etc/app \
+  && touch /etc/app/application.properties /var/log/app.log /var/log/app.err \
+  && chmod +x /docker-entrypoint.sh \
+  && chown $NONPRIVUSER:$NONPRIVGROUP /var/log/app.log /var/log/app.err
+
 COPY --from=builder /dist/production.jar ${JAR_FILE_BASEDIR}/${JAR_FILE_NAME}
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8080
+######## / COMMON BLOCK - PLEASE SYNC WITH PROD IMAGE / ############
+
 EXPOSE 5001
 CMD ["java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5001", "-jar","/opt/app/officeconverter.jar"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build: stop
-	docker pull ghcr.io/jodconverter/jodconverter-runtime:0.0.1
-	docker build --build-arg BASE_IMAGE_VERSION=0.0.1 --build-arg VERSION=0.1.0 --target development . -t ghcr.io/eugenmayer/kontextwork-converter:development
-	docker build --build-arg BASE_IMAGE_VERSION=0.0.1 --build-arg VERSION=0.1.0 --target production . -t ghcr.io/eugenmayer/kontextwork-converter:production
+	docker pull ghcr.io/jodconverter/jodconverter-runtime:0.1.1
+	docker build --build-arg BASE_IMAGE_VERSION=0.1.1 --build-arg VERSION=0.0.1-SNAPSHOT --target development . -t ghcr.io/eugenmayer/kontextwork-converter:development
+	docker build --build-arg BASE_IMAGE_VERSION=0.1.1 --build-arg VERSION=0.0.1-SNAPSHOT --target production . -t ghcr.io/eugenmayer/kontextwork-converter:production
 
 start-src: stop
 	./start.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build: stop
 	docker pull ghcr.io/jodconverter/jodconverter-runtime:0.1.1
-	docker build --build-arg BASE_IMAGE_VERSION=0.1.1 --build-arg VERSION=0.0.1-SNAPSHOT --target development . -t ghcr.io/eugenmayer/kontextwork-converter:development
-	docker build --build-arg BASE_IMAGE_VERSION=0.1.1 --build-arg VERSION=0.0.1-SNAPSHOT --target production . -t ghcr.io/eugenmayer/kontextwork-converter:production
+	docker build --build-arg BASE_IMAGE_VERSION=jdk-0.1.2 --build-arg VERSION=0.0.1-SNAPSHOT --target development . -t ghcr.io/eugenmayer/kontextwork-converter:development
+	docker build --build-arg BASE_IMAGE_VERSION=0.1.2 --build-arg VERSION=0.0.1-SNAPSHOT --target production . -t ghcr.io/eugenmayer/kontextwork-converter:production
 
 start-src: stop
 	./start.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+ifdef RUNTIME_VERSION
+    $(info RUNTIME_VERSION defined manually)
+else
+    RUNTIME_VERSION := 0.1.5
+endif
+
 build: stop
-	docker pull ghcr.io/jodconverter/jodconverter-runtime:0.1.1
-	docker build --build-arg BASE_IMAGE_VERSION=jdk-0.1.2 --build-arg VERSION=0.0.1-SNAPSHOT --target development . -t ghcr.io/eugenmayer/kontextwork-converter:development
-	docker build --build-arg BASE_IMAGE_VERSION=0.1.2 --build-arg VERSION=0.0.1-SNAPSHOT --target production . -t ghcr.io/eugenmayer/kontextwork-converter:production
+	docker build --pull --build-arg RUNTIME_VERSION=$(RUNTIME_VERSION) --build-arg VERSION=0.0.1-SNAPSHOT --target development . -t ghcr.io/eugenmayer/kontextwork-converter:development
+	docker build --pull --build-arg RUNTIME_VERSION=$(RUNTIME_VERSION) --build-arg VERSION=0.0.1-SNAPSHOT --target production . -t ghcr.io/eugenmayer/kontextwork-converter:production
 
 start-src: stop
 	./start.sh

--- a/README.md
+++ b/README.md
@@ -21,82 +21,14 @@ curl -F file=@src/test/resources/testfiles/withpictures.docx "localhost:14080/co
 curl -F file=@src/test/resources/testfiles/template.dotx "localhost:14080/conversion?format=html" -o /tmp/test.html
 ```
 
-## Build
-
-local java build, when you have all the build tools present + libreoffice locally installed
-
-    ./gradlew build
-    # you find the artifact in /tmp/gradle-officeconverter/builds/libs/officeconverter-*.jar
-    # the jar file is a full tomcat bundled app, so just start it like that
-    java -jar /tmp/gradle-officeconverter/build/libs/officeconverter-*.jar
-
-or better use the docker image with everything included, no dev tools/LO needed locally
-
-```bash
-# this builds the source a
-make build
-make start-prod
-```
-
-You can now connect to the 5001 remote debugger port, just use the existing IntelliJ task if you like
-
-## Tests
-
-You can run the tests locally (you will need libreoffice installed)
-
-```bash
-./gradlew itTests
-```
-
-Or in the docker-container
-
-```bash
-make test
-```
-
-## Development
-
-You can either use the IDE task or the local gradle
-
-    ./gradlew -Pdev bootRun
-
-Or even better, use the development container. You will not need any LibreOffice/Gradle installed locally
-
-     make start-src # basically just docker-compose up
-
-This fires up a docker container, mounts your source. To auto-rebuild and auto-restart he app very quick do this
-
-     make watch
-     # or just run ./watch.sh localy
-
-## Debugging
-
-Of course, you can just start using your IDE and debug that, but if you want to debug inside the docker container
-
-    make start
-
-And now connect(attach) to localhost 5001 for debugging `ghcr.io/eugenmayer/kontextwork-converter:development` has a default remote
-debugging port enabled on 5001
-
-## REST endpoints
+### REST endpoints
 
 Check the controller to understand the different endpoints
- 
+
 -  `/conversion?format=html` as multipart with `file` as the file to convert and `format` for the target format
 
-## Release
 
-CI based on tags
-
-### Upgrade
-
-To upgrade libreoffice or the jodconverter runtime
-
- - see available releases under https://github.com/jodconverter/docker-image-jodconverter-runtime
- - create pr and adjust docker-pr.yml and docker-publish.yml `BASE_IMAGE_VERSION` to match your version
- - merge PR if tests run successfully
-
-## Configuration
+### Configuration
 
 You can configure the docker images by mounting `/etc/app/application.yml` and put whatever you like into them.
 
@@ -128,6 +60,78 @@ You can edit the [src/resources/document-formats.json](src/resources/document-fo
 The original can be found at (https://github.com/jodconverter/jodconverter/blob/master/jodconverter-core/src/main/resources/document-formats.json)[jodconverter-core].
 
 We already added support for `dotx/xltx` for example.
+
+### Build
+
+local java build, when you have all the build tools present + libreoffice locally installed
+
+    ./gradlew build
+    # you find the artifact in /tmp/gradle-officeconverter/builds/libs/officeconverter-*.jar
+    # the jar file is a full tomcat bundled app, so just start it like that
+    java -jar /tmp/gradle-officeconverter/build/libs/officeconverter-*.jar
+
+or better use the docker image with everything included, no dev tools/LO needed locally
+
+```bash
+# this builds the source a
+make build
+make start-prod
+```
+
+You can now connect to the 5001 remote debugger port, just use the existing IntelliJ task if you like
+
+### Tests
+
+You can run the tests locally (you will need libreoffice installed)
+
+```bash
+./gradlew itTests
+```
+
+Or run the test in the docker-container
+
+```bash
+make test
+```
+
+## Development
+
+You can either use the IDE task or the local gradle
+
+    ./gradlew -Pdev bootRun
+
+Or even better, use the development container. You will not need any LibreOffice/Gradle installed locally
+
+     make start-src # basically just docker-compose up
+
+This fires up a docker container, mounts your source. To auto-rebuild and auto-restart he app very quick do this
+
+     make watch
+     # or just run ./watch.sh localy
+
+### Debugging
+
+Of course, you can just start using your IDE and debug that, but if you want to debug inside the docker container
+
+    make start
+
+And now connect(attach) to localhost 5001 for debugging `ghcr.io/eugenmayer/kontextwork-converter:development` has a default remote
+debugging port enabled on 5001
+
+
+## Release
+
+CI based on tags
+
+### Upgrade
+
+To upgrade libreoffice or the jodconverter runtime
+ - 
+ - see available releases under https://github.com/jodconverter/docker-image-jodconverter-runtime
+ - create pr and adjust `.github/docker-pr.yml` and `.github/docker-pr.yml` `RUNTIME_VERSION` to match your version
+ - Update the RUNTIME_VERSION in the `makefile`
+ - run `make test` and ensure the test run inside the docker container (against the pre-build libre office and the JDK version)
+ - merge PR if tests run successfully
 
 ## Internals
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Check the controller to understand the different endpoints
 
 CI based on tags
 
+### Upgrade
+
+To upgrade libreoffice or the jodconverter runtime
+
+ - see available releases under https://github.com/jodconverter/docker-image-jodconverter-runtime
+ - create pr and adjust docker-pr.yml and docker-publish.yml `BASE_IMAGE_VERSION` to match your version
+ - merge PR if tests run successfully
+
 ## Configuration
 
 You can configure the docker images by mounting `/etc/app/application.yml` and put whatever you like into them.

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -7,13 +7,14 @@ kotlin {
 
 compileKotlin {
     compilerOptions {
-        freeCompilerArgs = ["-Xjsr305=strict"]
+        freeCompilerArgs = ["-Xjsr305=strict", "-Xjvm-default=all", "-Xemit-jvm-type-annotations"]
     }
 }
 
 compileTestKotlin {
     compilerOptions {
-        freeCompilerArgs = ["-Xjsr305=strict"]
+        freeCompilerArgs = ["-Xjsr305=strict", "-Xjvm-default=all", "-Xemit-jvm-type-annotations"]
     }
 }
 
+ext["kotlin.version"] = "1.9.10"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,8 @@
 rootProject.name = 'officeconverter'
+// @see https://github.com/SonarSource/sonar-scanning-examples/issues/169#issuecomment-1769854089
+// @see https://community.sonarsource.com/t/sonar-gradle-skipcompile-is-not-working/102710/3
+System.setProperty("sonar.gradle.skipCompile", "true")
+
 // Composite build for library development
 //includeBuild("../jodconverter") {
 //    dependencySubstitution {


### PR DESCRIPTION
Upgrade to runtime 0.1.0

- libreoffice 7.4+
- debian bookworm
- jre 17
- add proper support for JDK in dev setups
- polish readme