### PR TITLE
Create gradle.yml to attach jar files to release

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,49 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Build and attach to release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write-all # To upload assets to release
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build
+
+    - name: Zip files in ./build/libs
+      run: |
+        cd ./build/libs
+        zip -r jar-files.zip ./*
+
+    - name: List contents of ./build/libs
+      run: ls ./build/libs
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: build/libs/jar-files.zip


### PR DESCRIPTION
Creates a zip with the contents of ./build/libs which I hope includes a shaded jar file, for people that do not want to use docker but directly run it via java themselves.