### PR TITLE
Implements a readiness endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -F file=@src/test/resources/testfiles/template.dotx "localhost:14080/conver
 Check the controller to understand the different endpoints
 
 -  `/conversion?format=html` as multipart with `file` as the file to convert and `format` for the target format
-- `/ready` is a readiness GET-endpoint that returns 200 OK when the application is ready, otherwise 503 Service Unavailable
+- `/ready` is a readiness GET-endpoint that returns 200 OK when the application is ready, otherwise 503 Service Unavailable. This *might* create some load, and should be used and monitored accordingly.
 
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ curl -F file=@src/test/resources/testfiles/template.dotx "localhost:14080/conver
 Check the controller to understand the different endpoints
 
 -  `/conversion?format=html` as multipart with `file` as the file to convert and `format` for the target format
+- `/ready` is a readiness GET-endpoint that returns 200 OK when the application is ready, otherwise 503 Service Unavailable
 
 
 ### Configuration

--- a/src/main/kotlin/de/kontextwork/converter/module/convert/ConverterService.kt
+++ b/src/main/kotlin/de/kontextwork/converter/module/convert/ConverterService.kt
@@ -43,4 +43,16 @@ class ConverterService(
             .execute()
         return outputStream
     }
+
+    fun isReady(): Boolean {
+        if (!officeManager.isRunning) {
+            return false
+        }
+
+        // Execute a dummy task
+        officeManager.execute { }
+
+        // If the above no-op task executed successfully, the application is ready
+        return true
+    }
 }

--- a/src/main/kotlin/de/kontextwork/converter/module/convert/controller/ConversionController.kt
+++ b/src/main/kotlin/de/kontextwork/converter/module/convert/controller/ConversionController.kt
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -62,5 +63,12 @@ class ConversionController(
         return ResponseEntity.ok().headers(headers).body(convertedFile.toByteArray())
     }
 
-
+    @GetMapping("/ready")
+    fun isReady(): ResponseEntity<Void> {
+        return if (converterService.isReady()) {
+            ResponseEntity.ok().build()
+        } else {
+            ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build()
+        }
+    }
 }


### PR DESCRIPTION
When this converter-application is deployed to a Kubernetes (or Kubernetes-like) environment, a readiness endpoint can be crucial for ensuring that the application has started and is ready to accept new connections.

The same endpoint can also be used in other contexts, like e.g. for testing that another application is able to reach the converter-application (used like a ping endpoint basically).

This new /ready endpoint checks that the officeManager in the converter service is running and can execute tasks, and responds with 200 OK if so. Otherwise it responds with 503 Service Unavailable